### PR TITLE
fix scope bug.

### DIFF
--- a/lib/encode-function.js
+++ b/lib/encode-function.js
@@ -52,20 +52,21 @@ const bySchema = (type, registry) => (topic, schema, msg, parseOptions = null) =
   }
   console.log(`Step 5, reqId: ${requestid} registry.cache.getBySchema didn't find id`);
 
+  let schemaName;
   if (type === "multi"){
     if (schema.namespace){
       console.log(`Step 6, reqId: ${requestid} in type multi with namespace: ${schema.namespace}, name: ${schema.name}`);
-      type = `${schema.namespace}.${schema.name}`;
+      schemaName = `${schema.namespace}.${schema.name}`;
       console.log(`Step 7, reqId: ${requestid} in type multi set type to ${topic}`);
     } else{
       console.log(`Step 8, reqId: ${requestid} in type multi without namespace. name: ${schema.name}`);
-      type = `${schema.name}`;
+      schemaName = `${schema.name}`;
       console.log(`Step 9, reqId: ${requestid} in type multi set type to ${topic}`);
     }
   }
 
   console.log(`Step 10, reqId: ${requestid} going to pushSchema with topic: ${topic}, schemaString: ${schemaString}, type: ${type}`);
-  return pushSchema(registry, topic, schemaString, type, requestid)
+  return pushSchema(registry, topic, schemaString, schemaName, requestid)
     .then(id => registry.cache.set(id, parsedSchema));
 })()
 .then(schemaId => {

--- a/lib/encode-function.js
+++ b/lib/encode-function.js
@@ -52,15 +52,15 @@ const bySchema = (type, registry) => (topic, schema, msg, parseOptions = null) =
   }
   console.log(`Step 5, reqId: ${requestid} registry.cache.getBySchema didn't find id`);
 
-  let schemaName;
+  let typeName;
   if (type === "multi"){
     if (schema.namespace){
       console.log(`Step 6, reqId: ${requestid} in type multi with namespace: ${schema.namespace}, name: ${schema.name}`);
-      schemaName = `${schema.namespace}.${schema.name}`;
+      typeName = `${schema.namespace}.${schema.name}`;
       console.log(`Step 7, reqId: ${requestid} in type multi set type to ${topic}`);
     } else{
       console.log(`Step 8, reqId: ${requestid} in type multi without namespace. name: ${schema.name}`);
-      schemaName = `${schema.name}`;
+      typeName = `${schema.name}`;
       console.log(`Step 9, reqId: ${requestid} in type multi set type to ${topic}`);
     }
   }

--- a/lib/encode-function.js
+++ b/lib/encode-function.js
@@ -66,7 +66,7 @@ const bySchema = (type, registry) => (topic, schema, msg, parseOptions = null) =
   }
 
   console.log(`Step 10, reqId: ${requestid} going to pushSchema with topic: ${topic}, schemaString: ${schemaString}, type: ${type}`);
-  return pushSchema(registry, topic, schemaString, schemaName, requestid)
+  return pushSchema(registry, topic, schemaString, typeName, requestid)
     .then(id => registry.cache.set(id, parsedSchema));
 })()
 .then(schemaId => {


### PR DESCRIPTION
There is a scope bug, here is a demo:

const testFunc = (parentScope) => (childScope) => {
  console.log(`Entry - parentScope: ${parentScope}, childScope: ${childScope}`);
  if (parentScope === 'first') {
    parentScope = childScope;
  }
  console.log(`Exit - parentScope: ${parentScope}, childScope: ${childScope}`);
}
const childFunc = testFunc('first');
let i;
for(i = 1; i <= 10; i++) {
  childFunc(`call${i}`);
}
output:
Entry - parentScope: first, childScope: call1
Exit - parentScope: call1, childScope: call1
Entry - parentScope: call1, childScope: call2
Exit - parentScope: call1, childScope: call2
Entry - parentScope: call1, childScope: call3
Exit - parentScope: call1, childScope: call3
Entry - parentScope: call1, childScope: call4
Exit - parentScope: call1, childScope: call4
Entry - parentScope: call1, childScope: call5
Exit - parentScope: call1, childScope: call5
Entry - parentScope: call1, childScope: call6
Exit - parentScope: call1, childScope: call6
Entry - parentScope: call1, childScope: call7
Exit - parentScope: call1, childScope: call7
Entry - parentScope: call1, childScope: call8
Exit - parentScope: call1, childScope: call8
Entry - parentScope: call1, childScope: call9
Exit - parentScope: call1, childScope: call9
Entry - parentScope: call1, childScope: call10
Exit - parentScope: call1, childScope: call10